### PR TITLE
use static callback functions which improves performance by ~3% 

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -62,7 +62,7 @@ final class Parser
     {
         return new Parser(
         // Make a placeholder parser that will throw when you try to run it.
-            function (Stream $input): ParseResult {
+            static function (Stream $input): ParseResult {
                 throw new Exception(
                     "Can't run a recursive parser that hasn't been setup properly yet. "
                     . "A parser created by recursive(), must then be called with ->recurse(Parser) "
@@ -377,9 +377,11 @@ final class Parser
      */
     public function label(string $label): Parser
     {
-        $newParserFunction = function (Stream $input) use ($label) : ParseResult {
+        $parserFn = $this->parserFunction;
+
+        $newParserFunction = static function (Stream $input) use ($parserFn, $label) : ParseResult {
             /** @psalm-var ParseResult $result */
-            $result = ($this->parserFunction)($input);
+            $result = ($parserFn)($input);
             return ($result->isSuccess())
                 ? $result
                 : new Fail($label, $result->got());

--- a/src/combinators.php
+++ b/src/combinators.php
@@ -80,7 +80,7 @@ function optional(Parser $parser): Parser
 function bind(Parser $parser, callable $f): Parser
 {
     /** @psalm-var Parser<T2> $finalParser */
-    $finalParser = Parser::make($parser->getLabel(), function (Stream $input) use ($parser, $f) : ParseResult {
+    $finalParser = Parser::make($parser->getLabel(), static function (Stream $input) use ($parser, $f) : ParseResult {
         $result = $parser->run($input)->map($f);
         if ($result->isFail()) {
             return $result;
@@ -109,7 +109,7 @@ function bind(Parser $parser, callable $f): Parser
 function apply(Parser $parser1, Parser $parser2): Parser
 {
     /** @psalm-var Parser<T2> $parser */
-    $parser = Parser::make($parser1->getLabel(), function (Stream $input) use ($parser2, $parser1) : ParseResult {
+    $parser = Parser::make($parser1->getLabel(), static function (Stream $input) use ($parser2, $parser1) : ParseResult {
         $r1 = $parser1->run($input);
         if ($r1->isFail()) {
             return $r1;
@@ -189,7 +189,7 @@ function keepSecond(Parser $first, Parser $second): Parser
 function either(Parser $first, Parser $second): Parser
 {
     $label = $first->getLabel() . " or " . $second->getLabel();
-    return Parser::make($label, function (Stream $input) use ($second, $first, $label): ParseResult {
+    return Parser::make($label, static function (Stream $input) use ($second, $first, $label): ParseResult {
         // @todo Megaparsec doesn't do automatic rollback, for performance reasons, and requires the user to add try
         //       combinators. We could mimic that behaviour as it is probably more performant
         $r1 = $first->run($input);
@@ -220,7 +220,7 @@ function either(Parser $first, Parser $second): Parser
  */
 function append(Parser $left, Parser $right): Parser
 {
-    return Parser::make($right->getLabel(), function (Stream $input) use ($left, $right): ParseResult {
+    return Parser::make($right->getLabel(), static function (Stream $input) use ($left, $right): ParseResult {
         $r1 = $left->run($input);
         $r2 = $r1->continueWith($right);
         return $r1->append($r2);
@@ -317,7 +317,7 @@ function atLeastOne(Parser $parser): Parser
 {
     return Parser::make(
         "at least one " . $parser->getLabel(),
-        function (Stream $input) use ($parser) : ParseResult {
+        static function (Stream $input) use ($parser) : ParseResult {
             $result = $parser->run($input);
             if ($result->isFail()) {
                 return $result;
@@ -347,7 +347,7 @@ function zeroOrMore(Parser $parser): Parser
 {
     return Parser::make(
         "zero or more " . $parser->getLabel(),
-        function (Stream $input) use ($parser) : ParseResult {
+        static function (Stream $input) use ($parser) : ParseResult {
             $result = new Succeed(null, $input);
             $final = $result;
             while ($result->isSuccess()) {
@@ -562,7 +562,7 @@ function notFollowedBy(Parser $parser): Parser
     /** @psalm-var Parser<string> $p */
     $label = "notFollowedBy({$parser->getLabel()})";
 
-    $p = Parser::make($label, function (Stream $input) use ($label, $parser): ParseResult {
+    $p = Parser::make($label, static function (Stream $input) use ($label, $parser): ParseResult {
         $result = $parser->run($input);
         return $result->isSuccess()
             ? new Fail($label, $input)
@@ -600,7 +600,7 @@ function lookAhead(Parser $parser): Parser
 {
     return Parser::make(
         $parser->getLabel(),
-        function (Stream $input) use ($parser): ParseResult {
+        static function (Stream $input) use ($parser): ParseResult {
             $parseResult = $parser->run($input);
             return $parseResult->isSuccess()
                 ? new Succeed($parseResult->output(), $input)

--- a/src/primitives.php
+++ b/src/primitives.php
@@ -28,7 +28,7 @@ use Parsica\Parsica\Internal\Succeed;
 function satisfy(callable $predicate): Parser
 {
     $label = "satisfy(predicate)";
-    return Parser::make($label, function (Stream $input) use ($label, $predicate) : ParseResult {
+    return Parser::make($label, static function (Stream $input) use ($label, $predicate) : ParseResult {
         try {
             $t = $input->take1();
         } catch (EndOfStream $e) {
@@ -78,7 +78,7 @@ function takeWhile(callable $predicate): Parser
 {
     return Parser::make(
         "takeWhile(predicate)",
-        function (Stream $input) use ($predicate): ParseResult {
+        static function (Stream $input) use ($predicate): ParseResult {
             $t = $input->takeWhile($predicate);
             return new Succeed($t->chunk(), $t->stream());
         }
@@ -98,7 +98,7 @@ function takeWhile(callable $predicate): Parser
 function takeWhile1(callable $predicate): Parser
 {
     $label = "takeWhile1(predicate)";
-    return Parser::make($label, function (Stream $input) use ($label, $predicate): ParseResult {
+    return Parser::make($label, static function (Stream $input) use ($label, $predicate): ParseResult {
 
         try {
             $t = $input->take1();

--- a/src/sideEffects.php
+++ b/src/sideEffects.php
@@ -24,7 +24,7 @@ namespace Parsica\Parsica;
  */
 function emit(Parser $parser, callable $receiver): Parser
 {
-    return Parser::make("emit", function (Stream $input) use ($receiver, $parser): ParseResult {
+    return Parser::make("emit", static function (Stream $input) use ($receiver, $parser): ParseResult {
         $result = $parser->run($input);
         if ($result->isSuccess()) {
             $receiver($result->output());

--- a/src/strings.php
+++ b/src/strings.php
@@ -30,7 +30,7 @@ function string(string $str): Parser
     $len = mb_strlen($str);
     $label = "'$str'";
     /** @psalm-var Parser<string> $parser */
-    $parser = Parser::make($label, function (Stream $input) use ($label, $len, $str): ParseResult {
+    $parser = Parser::make($label, static function (Stream $input) use ($label, $len, $str): ParseResult {
         try {
             $t = $input->takeN($len);
         } catch (EndOfStream $e) {


### PR DESCRIPTION
inspired by your blackfire session on twitch yesterday, I took a stab at improving performance on parsica.

![grafik](https://user-images.githubusercontent.com/120441/111025476-b48f3b80-83e4-11eb-8741-0bc8a1a3657f.png)

https://blackfire.io/profiles/compare/554e2a9c-1726-43a1-b626-95aa2a230949/graph

using `static function` instead of `function` reduces overhead of php in callables, because the runtime does not need to introduce a `$this` object for each function.