### PR TITLE
prevent use ob mb_* functions on non-multibyte strings - 2,8% perf gain

### DIFF
--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,12 +8,14 @@
  * file that was distributed with this source code.
  */
 
+require_once __DIR__.'/../vendor/autoload.php';
+
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private string $data;
+    private $data;
 
     function __construct()
     {
@@ -54,32 +56,11 @@ JSON;
 
     }
 
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_json_encode()
-    {
-        json_decode($this->data);
-    }
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
-
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_basemax_jpophp()
-    {
-        require_once(__DIR__.'/JPOPHP/JsonParser.php');
-        (new JPOPHP\Json())->decode($this->data);
-    }
 }
+
+
+(new JSONBench)->bench_Parsica_JSON();

--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,14 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../vendor/autoload.php';
-
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private $data;
+    private string $data;
 
     function __construct()
     {
@@ -56,11 +54,32 @@ JSON;
 
     }
 
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_json_encode()
+    {
+        json_decode($this->data);
+    }
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
+
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_basemax_jpophp()
+    {
+        require_once(__DIR__.'/JPOPHP/JsonParser.php');
+        (new JPOPHP\Json())->decode($this->data);
+    }
 }
-
-
-(new JSONBench)->bench_Parsica_JSON();

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -143,13 +143,13 @@ final class StringStream implements Stream
         }
 
         $remaining = $this->string;
-        $nextToken = $this->substr($remaining, 0, 1);
+        $nextToken = mb_substr($remaining, 0, 1);
         $chunk = "";
         while ($predicate($nextToken)) {
             $chunk .= $nextToken;
-            $remaining = $this->substr($remaining, 1);
+            $remaining = mb_substr($remaining, 1);
             if (mb_strlen($remaining) > 0) {
-                $nextToken = $this->substr($remaining, 0, 1);
+                $nextToken = mb_substr($remaining, 0, 1);
             } else {
                 break;
             }

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -31,7 +31,7 @@ final class StringStream implements Stream
         $this->string = $string;
         $this->position = $position ?? Position::initial();
         if (null === $containsMultiBytes) {
-            $this->containsMultiBytes = mb_strlen($string) != strlen($string);
+            $this->containsMultiBytes = \mb_strlen($string) != \strlen($string);
         } else {
             $this->containsMultiBytes = $containsMultiBytes;
         }
@@ -46,15 +46,15 @@ final class StringStream implements Stream
     private function substr($string, $start, $length = null):string {
         if ($this->containsMultiBytes) {
             if ($length) {
-                return mb_substr($string, $start, $length);
+                return \mb_substr($string, $start, $length);
             }
-            return mb_substr($string, $start);
+            return \mb_substr($string, $start);
         }
 
         if ($length) {
-            return substr($string, $start, $length);
+            return \substr($string, $start, $length);
         }
-        return substr($string, $start);
+        return \substr($string, $start);
     }
 
     /**
@@ -62,9 +62,9 @@ final class StringStream implements Stream
      */
     private function strlen($string):int {
         if ($this->containsMultiBytes) {
-            return mb_strlen($string);
+            return \mb_strlen($string);
         }
-        return strlen($string);
+        return \strlen($string);
     }
 
     /**

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -109,7 +109,7 @@ final class StringStream implements Stream
      */
     public function isEOF(): bool
     {
-        return $this->strlen($this->string) === 0;
+        return mb_strlen($this->string) === 0;
     }
 
     /**
@@ -123,11 +123,11 @@ final class StringStream implements Stream
 
         $this->guardEndOfStream();
 
-        $chunk = $this->substr($this->string, 0, $n);
+        $chunk = mb_substr($this->string, 0, $n);
         return new TakeResult(
             $chunk,
             new StringStream(
-                $this->substr($this->string, $n),
+                mb_substr($this->string, $n),
                 $this->position->advance($chunk)
             )
         );

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -75,12 +75,22 @@ final class StringStream implements Stream
     {
         $this->guardEndOfStream();
 
-        $token = $this->substr($this->string, 0, 1);
+        if ($this->containsMultiBytes) {
+            $token = \mb_substr($this->string, 0, 1);
+        } else {
+            $token = \substr($this->string, 0, 1);
+        }
         $position = $this->position->advance($token);
+
+        if ($this->containsMultiBytes) {
+            $remainder = \mb_substr($this->string, 1);
+        } else {
+            $remainder = \substr($this->string, 1);
+        }
 
         return new TakeResult(
             $token,
-            new StringStream($this->substr($this->string, 1), $position, $this->containsMultiBytes)
+            new StringStream($remainder, $position, $this->containsMultiBytes)
         );
     }
 

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -38,36 +38,6 @@ final class StringStream implements Stream
     }
 
     /**
-     * Performance optimized substr() implementation
-     *
-     * @param int $start The first position used in str.
-     * @param int $length [optional] The maximum length of the returned string.
-     */
-    private function substr($string, $start, $length = null):string {
-        if ($this->containsMultiBytes) {
-            if ($length) {
-                return \mb_substr($string, $start, $length);
-            }
-            return \mb_substr($string, $start);
-        }
-
-        if ($length) {
-            return \substr($string, $start, $length);
-        }
-        return \substr($string, $start);
-    }
-
-    /**
-     * Performance optimized strlen() implementation
-     */
-    private function strlen($string):int {
-        if ($this->containsMultiBytes) {
-            return \mb_strlen($string);
-        }
-        return \strlen($string);
-    }
-
-    /**
      * @inheritDoc
      * @internal
      */


### PR DESCRIPTION
this PR does 2 things

- use `mb_*` functions only, when the string beeing streamed contains multibyte chars. that way we can use way faster non mb-string functions on non-multibyte strings
- use full-qualified call to string and multibyte-string functions, which allows the php parser to apply compile time optimizations when strings are known (e.g. string literals)

![grafik](https://user-images.githubusercontent.com/120441/111027063-28821180-83ee-11eb-9c7b-348c4b7d3e69.png)
