### PR TITLE
remove unnecessary indirection via guardEndOfStream() which gains ~4% performance

### DIFF
--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,12 +8,14 @@
  * file that was distributed with this source code.
  */
 
+require_once __DIR__.'/../vendor/autoload.php';
+
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private string $data;
+    private $data;
 
     function __construct()
     {
@@ -54,32 +56,11 @@ JSON;
 
     }
 
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_json_encode()
-    {
-        json_decode($this->data);
-    }
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
-
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_basemax_jpophp()
-    {
-        require_once(__DIR__.'/JPOPHP/JsonParser.php');
-        (new JPOPHP\Json())->decode($this->data);
-    }
 }
+
+
+(new JSONBench)->bench_Parsica_JSON();

--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,14 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../vendor/autoload.php';
-
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private $data;
+    private string $data;
 
     function __construct()
     {
@@ -56,11 +54,32 @@ JSON;
 
     }
 
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_json_encode()
+    {
+        json_decode($this->data);
+    }
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
+
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_basemax_jpophp()
+    {
+        require_once(__DIR__.'/JPOPHP/JsonParser.php');
+        (new JPOPHP\Json())->decode($this->data);
+    }
 }
-
-
-(new JSONBench)->bench_Parsica_JSON();

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -37,7 +37,9 @@ final class StringStream implements Stream
      */
     public function take1(): TakeResult
     {
-        $this->guardEndOfStream();
+        if ($this->isEOF()) {
+            throw new EndOfStream("End of stream was reached in " . $this->position->pretty());
+        }
 
         $token = mb_substr($this->string, 0, 1);
         $position = $this->position->advance($token);
@@ -46,16 +48,6 @@ final class StringStream implements Stream
             $token,
             new StringStream(mb_substr($this->string, 1), $position)
         );
-    }
-
-    /**
-     * @throws EndOfStream
-     */
-    private function guardEndOfStream(): void
-    {
-        if ($this->isEOF()) {
-            throw new EndOfStream("End of stream was reached in " . $this->position->pretty());
-        }
     }
 
     /**
@@ -75,7 +67,9 @@ final class StringStream implements Stream
             return new TakeResult("", $this);
         }
 
-        $this->guardEndOfStream();
+        if ($this->isEOF()) {
+            throw new EndOfStream("End of stream was reached in " . $this->position->pretty());
+        }
 
         $chunk = mb_substr($this->string, 0, $n);
         return new TakeResult(

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -37,7 +37,7 @@ final class StringStream implements Stream
      */
     public function take1(): TakeResult
     {
-        if ($this->isEOF()) {
+        if ($this->string === '') {
             throw new EndOfStream("End of stream was reached in " . $this->position->pretty());
         }
 
@@ -67,7 +67,7 @@ final class StringStream implements Stream
             return new TakeResult("", $this);
         }
 
-        if ($this->isEOF()) {
+        if ($this->string === '') {
             throw new EndOfStream("End of stream was reached in " . $this->position->pretty());
         }
 
@@ -86,7 +86,7 @@ final class StringStream implements Stream
      */
     public function takeWhile(callable $predicate): TakeResult
     {
-        if($this->isEOF()) {
+        if($this->string === '') {
             return new TakeResult("", $this);
         }
 


### PR DESCRIPTION
this function overhead call on the hot path is expensive (in take1)

![grafik](https://user-images.githubusercontent.com/120441/111026097-cbd02800-83e8-11eb-9dd3-676cb0bc8be8.png)

getting rid of the fn call therefore translates into a small perf boost

![grafik](https://user-images.githubusercontent.com/120441/111026079-b22ee080-83e8-11eb-9151-b6e0f26f588f.png)

