### PR TITLE
⚡️ Use `strlen()` instead of `mb_strlen()` to find EOF

### DIFF
--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -63,7 +63,7 @@ final class StringStream implements Stream
      */
     public function isEOF(): bool
     {
-        return mb_strlen($this->string) === 0;
+        return strlen($this->string) === 0;
     }
 
     /**


### PR DESCRIPTION
To find EOF, we just want to know if the length of the remaining string
is 0. We don't need to use `mb_strlen()` for that, because in an empty
string, there shouldn't be any multibyte characters anyway.

See also #32

Co-authored-by: Markus Staab <markus.staab@redaxo.de>