### PR TITLE
Succeed: use property instead of internal getter call on the hot path - gains ~7.5%

### DIFF
--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,12 +8,14 @@
  * file that was distributed with this source code.
  */
 
+require_once __DIR__.'/../vendor/autoload.php';
+
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private string $data;
+    private $data;
 
     function __construct()
     {
@@ -54,32 +56,11 @@ JSON;
 
     }
 
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_json_encode()
-    {
-        json_decode($this->data);
-    }
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
-
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_basemax_jpophp()
-    {
-        require_once(__DIR__.'/JPOPHP/JsonParser.php');
-        (new JPOPHP\Json())->decode($this->data);
-    }
 }
+
+
+(new JSONBench)->bench_Parsica_JSON();

--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,14 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../vendor/autoload.php';
-
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private $data;
+    private string $data;
 
     function __construct()
     {
@@ -56,11 +54,32 @@ JSON;
 
     }
 
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_json_encode()
+    {
+        json_decode($this->data);
+    }
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
+
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_basemax_jpophp()
+    {
+        require_once(__DIR__.'/JPOPHP/JsonParser.php');
+        (new JPOPHP\Json())->decode($this->data);
+    }
 }
-
-
-(new JSONBench)->bench_Parsica_JSON();

--- a/src/Internal/Succeed.php
+++ b/src/Internal/Succeed.php
@@ -153,7 +153,7 @@ final class Succeed implements ParseResult
      */
     public function continueWith(Parser $parser): ParseResult
     {
-        return $parser->run($this->remainder());
+        return $parser->run($this->remainder);
     }
 
     /**


### PR DESCRIPTION
reduces a unneccessary method call on a very hot path.
since the class is final, this has no BC impact.

![grafik](https://user-images.githubusercontent.com/120441/111061014-64c27a00-84a1-11eb-8de3-c91f8aae964f.png)
