### PR TITLE
 Succeed: use private properties lookup instead of calling getters - gains ~6%

### DIFF
--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,12 +8,14 @@
  * file that was distributed with this source code.
  */
 
+require_once __DIR__.'/../vendor/autoload.php';
+
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private string $data;
+    private $data;
 
     function __construct()
     {
@@ -54,32 +56,11 @@ JSON;
 
     }
 
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_json_encode()
-    {
-        json_decode($this->data);
-    }
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
-
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_basemax_jpophp()
-    {
-        require_once(__DIR__.'/JPOPHP/JsonParser.php');
-        (new JPOPHP\Json())->decode($this->data);
-    }
 }
+
+
+(new JSONBench)->bench_Parsica_JSON();

--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,14 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../vendor/autoload.php';
-
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private $data;
+    private string $data;
 
     function __construct()
     {
@@ -56,11 +54,32 @@ JSON;
 
     }
 
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_json_encode()
+    {
+        json_decode($this->data);
+    }
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
+
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_basemax_jpophp()
+    {
+        require_once(__DIR__.'/JPOPHP/JsonParser.php');
+        (new JPOPHP\Json())->decode($this->data);
+    }
 }
-
-
-(new JSONBench)->bench_Parsica_JSON();

--- a/src/Internal/Succeed.php
+++ b/src/Internal/Succeed.php
@@ -103,11 +103,11 @@ final class Succeed implements ParseResult
 
         // Ignore nulls
         if($type1 === 'NULL' && $type2 === 'NULL') {
-            return new Succeed(null, $other->remainder());
+            return new Succeed(null, $other->remainder);
         } elseif($type1 !== 'NULL' && $type2 === 'NULL') {
-            return new Succeed($this->output(), $other->remainder());
+            return new Succeed($this->output, $other->remainder);
         } elseif($type1 === 'NULL' && $type2 !== 'NULL') {
-            return new Succeed($other->output(), $other->remainder());
+            return new Succeed($other->output, $other->remainder);
         }
 
         // Only append for the same type
@@ -118,12 +118,12 @@ final class Succeed implements ParseResult
         switch ($type1) {
             case 'string':
                 /** @psalm-suppress MixedOperand */
-                return new Succeed($this->output() . $other->output(), $other->remainder());
+                return new Succeed($this->output . $other->output, $other->remainder);
             case 'array':
                 /** @psalm-suppress MixedArgument */
                 return new Succeed(
-                    array_merge($this->output(), $other->output()),
-                    $other->remainder()
+                    array_merge($this->output, $other->output),
+                    $other->remainder
                 );
             default:
                 throw new Exception("@TODO cannot append ParseResult<$type1>");


### PR DESCRIPTION
its technically allowed to do property lookups of private properties on objects of the same class, within said class. this reduces a unneccessary method call on a very hot path.

![grafik](https://user-images.githubusercontent.com/120441/111061258-ba4b5680-84a2-11eb-9c02-5ec1088ab05b.png)


before
```
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-------------+--------+-----------+
| benchmark | subject              | set | revs | its | mem_peak   | best         | mean         | mode         | worst        | stdev       | rstdev | diff      |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-------------+--------+-----------+
| JSONBench | bench_json_encode    | 0   | 5    | 3   | 1,661,896b | 13.200μs     | 13.267μs     | 13.212μs     | 13.400μs     | 0.094μs     | 0.71%  | 1.00x     |
| JSONBench | bench_Parsica_JSON   | 0   | 5    | 3   | 2,183,336b | 21,485.600μs | 23,175.600μs | 22,103.476μs | 25,870.800μs | 1,926.191μs | 8.31%  | 1,746.90x |
| JSONBench | bench_basemax_jpophp | 0   | 5    | 3   | 1,868,392b | 1,399.200μs  | 1,546.600μs  | 1,541.986μs  | 1,695.800μs  | 121.093μs   | 7.83%  | 116.58x   |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-------------+--------+-----------+
```

after
```
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
| benchmark | subject              | set | revs | its | mem_peak   | best         | mean         | mode         | worst        | stdev     | rstdev | diff      |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
| JSONBench | bench_json_encode    | 0   | 5    | 3   | 1,661,896b | 13.200μs     | 13.400μs     | 13.400μs     | 13.600μs     | 0.163μs   | 1.22%  | 1.00x     |
| JSONBench | bench_Parsica_JSON   | 0   | 5    | 3   | 2,183,336b | 21,035.800μs | 21,383.533μs | 21,287.141μs | 21,778.200μs | 304.895μs | 1.43%  | 1,595.79x |
| JSONBench | bench_basemax_jpophp | 0   | 5    | 3   | 1,868,392b | 1,360.000μs  | 1,368.200μs  | 1,361.492μs  | 1,384.600μs  | 11.597μs  | 0.85%  | 102.10x   |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
```