### PR TITLE
Succeed: simplify appendSuccess

### DIFF
--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,12 +8,14 @@
  * file that was distributed with this source code.
  */
 
+require_once __DIR__.'/../vendor/autoload.php';
+
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private string $data;
+    private $data;
 
     function __construct()
     {
@@ -54,32 +56,11 @@ JSON;
 
     }
 
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_json_encode()
-    {
-        json_decode($this->data);
-    }
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
-
-
-    /**
-     * @Revs(5)
-     * @Iterations(3)
-     */
-    public function bench_basemax_jpophp()
-    {
-        require_once(__DIR__.'/JPOPHP/JsonParser.php');
-        (new JPOPHP\Json())->decode($this->data);
-    }
 }
+
+
+(new JSONBench)->bench_Parsica_JSON();

--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -8,14 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../vendor/autoload.php';
-
 use Parsica\Parsica\JSON\JSON as ParsicaJSON;
 use Json as BaseMaxJson;
 
 class JSONBench
 {
-    private $data;
+    private string $data;
 
     function __construct()
     {
@@ -56,11 +54,32 @@ JSON;
 
     }
 
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_json_encode()
+    {
+        json_decode($this->data);
+    }
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
     public function bench_Parsica_JSON()
     {
         $result = ParsicaJSON::json()->tryString($this->data);
     }
+
+
+    /**
+     * @Revs(5)
+     * @Iterations(3)
+     */
+    public function bench_basemax_jpophp()
+    {
+        require_once(__DIR__.'/JPOPHP/JsonParser.php');
+        (new JPOPHP\Json())->decode($this->data);
+    }
 }
-
-
-(new JSONBench)->bench_Parsica_JSON();


### PR DESCRIPTION
remove calls to `gettype()` which is the most expensive operation within `appendSuccess`

![grafik](https://user-images.githubusercontent.com/120441/111083196-8efd5180-850c-11eb-88f0-e75ec31a7705.png)


before
```
staabm@staabm_laptop MINGW64 /c/xampp7.3/htdocs/redaxo/redaxo/src/addons/parsica (simplify-type)
$ /c/xampp7.4.2/php/php /c/dev/composer/vendor/bin/phpbench run benchmarks --report=aggregate  --retry-threshold=5
PHPBench @git_tag@ running benchmarks...
with configuration file: C:\xampp7.3\htdocs\redaxo\redaxo\src\addons\parsica/phpbench.json
with PHP version 7.4.1, xdebug ❌, opcache ❌

\JSONBench

    bench_json_encode.......................I2 ✔ Mo13.241μs (±1.899%)
    bench_Parsica_JSON......................I2 ✔ Mo21,338.523μs (±1.071%)
    bench_basemax_jpophp....................I2 ✔ Mo1,375.314μs (±0.654%)

⅀T: 67,812.200μs μSD/r 78.783μs μRSD/r: 1.208%

Subjects: 3, Assertions: 0, Failures: 0, Errors: 0
suite: 134628a77f5b70ee8034abd04114ab3247c4f4cd, date: 2021-03-14, stime: 21:27:10
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
| benchmark | subject              | set | revs | its | mem_peak   | best         | mean         | mode         | worst        | stdev     | rstdev | diff      |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
| JSONBench | bench_json_encode    | 0   | 5    | 3   | 1,666,776b | 12.800μs     | 13.133μs     | 13.241μs     | 13.400μs     | 0.249μs   | 1.90%  | 1.00x     |
| JSONBench | bench_Parsica_JSON   | 0   | 5    | 3   | 2,182,400b | 20,891.400μs | 21,210.467μs | 21,338.523μs | 21,401.400μs | 227.066μs | 1.07%  | 1,615.01x |
| JSONBench | bench_basemax_jpophp | 0   | 5    | 3   | 1,867,520b | 1,373.200μs  | 1,380.467μs  | 1,375.314μs  | 1,393.200μs  | 9.034μs   | 0.65%  | 105.11x   |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
```

after
```
staabm@staabm_laptop MINGW64 /c/xampp7.3/htdocs/redaxo/redaxo/src/addons/parsica (simplify-type)
$ /c/xampp7.4.2/php/php /c/dev/composer/vendor/bin/phpbench run benchmarks --report=aggregate  --retry-threshold=5
PHPBench @git_tag@ running benchmarks...
with configuration file: C:\xampp7.3\htdocs\redaxo\redaxo\src\addons\parsica/phpbench.json
with PHP version 7.4.1, xdebug ❌, opcache ❌

\JSONBench

    bench_json_encode.......................I2 ✔ Mo13.436μs (±2.08%)
    bench_Parsica_JSON......................I2 ✔ Mo20,541.307μs (±2.514%)
    bench_basemax_jpophp....................R3 I2 ✔ Mo1,366.153μs (±1.837%)

⅀T: 66,626.400μs μSD/r 182.998μs μRSD/r: 2.143%

Subjects: 3, Assertions: 0, Failures: 0, Errors: 0
suite: 134628ae7cb50c4018c4881c0c020c1f4335617d, date: 2021-03-14, stime: 21:26:40
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
| benchmark | subject              | set | revs | its | mem_peak   | best         | mean         | mode         | worst        | stdev     | rstdev | diff      |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
| JSONBench | bench_json_encode    | 0   | 5    | 3   | 1,666,792b | 13.400μs     | 13.600μs     | 13.436μs     | 14.000μs     | 0.283μs   | 2.08%  | 1.00x     |
| JSONBench | bench_Parsica_JSON   | 0   | 5    | 3   | 2,180,704b | 20,411.200μs | 20,840.067μs | 20,541.307μs | 21,577.600μs | 523.818μs | 2.51%  | 1,532.36x |
| JSONBench | bench_basemax_jpophp | 0   | 5    | 3   | 1,867,520b | 1,321.800μs  | 1,355.133μs  | 1,366.153μs  | 1,381.600μs  | 24.891μs  | 1.84%  | 99.64x    |
+-----------+----------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+-----------+--------+-----------+
```