### PR TITLE
⚡️ Make many 400% faster by using while instead of recurse

### DIFF
--- a/benchmarks/ManyBench.php
+++ b/benchmarks/ManyBench.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Parsica library.
+ *
+ * Copyright (c) 2020 Mathias Verraes <mathias@verraes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Parsica\Parsica\Parser;
+use function Parsica\Parsica\any;
+use function Parsica\Parsica\char;
+use function Parsica\Parsica\collect;
+use function Parsica\Parsica\many;
+use function Parsica\Parsica\map;
+use function Parsica\Parsica\pure;
+use function Parsica\Parsica\recursive;
+use function Parsica\Parsica\satisfy;
+use function Parsica\Parsica\takeWhile;
+
+class ManyBench
+{
+    private string $data;
+
+    function __construct()
+    {
+        $this->data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        $this->takeWhile = takeWhile(fn(string $c): bool => $c === 'a');
+        $this->manySatisfy = many(satisfy(fn(string $c): bool => $c === 'a'));
+        $this->manyChar = many(char('a'));
+        $this->oldManySatisfy = static::oldMany(satisfy(fn(string $c): bool => $c === 'a'));
+        $this->oldManyChar = static::oldMany(char('a'));
+    }
+
+    /**
+     * @Revs(10)
+     * @Iterations(10)
+     */
+    public function bench_takeWhile()
+    {
+        $result = $this->takeWhile->tryString($this->data);
+    }
+
+    /**
+     * @Revs(10)
+     * @Iterations(10)
+     */
+    public function bench_manySatisfy()
+    {
+        $result = $this->manySatisfy->tryString($this->data);
+    }
+
+    /**
+     * @Revs(10)
+     * @Iterations(10)
+     */
+    public function bench_manyChar()
+    {
+        $result = $this->manyChar->tryString($this->data);
+    }
+
+    /**
+     * @Revs(10)
+     * @Iterations(10)
+     */
+    public function bench_oldManySatisfy()
+    {
+        $result = $this->oldManySatisfy->tryString($this->data);
+    }
+
+    /**
+     * @Revs(10)
+     * @Iterations(10)
+     */
+    public function bench_oldManyChar()
+    {
+        $result = $this->oldManyChar->tryString($this->data);
+    }
+
+    public static function oldMany(Parser $parser)
+    {
+        $rec = recursive();
+        $rec->recurse(
+            any(
+                map(
+                    collect($parser, $rec),
+                    fn(array $o): array => array_merge([$o[0]], $o[1])
+                ),
+                pure([]),
+            )
+        );
+        return $rec;
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -74,11 +74,13 @@ final class Parser
     /**
      * Make a new parser.
      *
-     * @psalm-param callable(Stream) : ParseResult<T2> $parserFunction
+     * @internal
+     *
+     * @template T2
+     *
+     * @psalm-param callable(Stream):ParseResult<T2> $parserFunction
      *
      * @psalm-return Parser<T2>
-     * @internal
-     * @template T2
      */
     public static function make(string $label, callable $parserFunction): Parser
     {

--- a/src/combinators.php
+++ b/src/combinators.php
@@ -432,14 +432,16 @@ function some(Parser $parser): Parser
  *
  * @psalm-param Parser<T> $parser
  * @psalm-return Parser<list<T>>
+ * @psalm-suppress MixedReturnTypeCoercion
+ *
  * @api
  */
 function many(Parser $parser): Parser
 {
     return Parser::make(
         "many {$parser->getLabel()}",
-        function ($remainder) use ($parser) {
-            $result = array();
+        function (Stream $remainder) use ($parser): ParseResult {
+            $result = [];
 
             while (true) {
                 $lastResult = $parser->run($remainder);

--- a/src/combinators.php
+++ b/src/combinators.php
@@ -432,7 +432,6 @@ function some(Parser $parser): Parser
  *
  * @psalm-param Parser<T> $parser
  * @psalm-return Parser<list<T>>
- * @psalm-suppress MixedReturnTypeCoercion
  *
  * @api
  */
@@ -454,7 +453,10 @@ function many(Parser $parser): Parser
                 $result[] = $lastResult->output();
             }
 
-            return new Succeed($result, $remainder);
+            /** @psalm-var ParseResult<list<T>> $succeed */
+            $succeed = new Succeed($result, $remainder);
+
+            return $succeed;
         }
     );
 }


### PR DESCRIPTION
- Added a benchmark which encapsulates the old implementation and
  compares to the new implementation
- Created the new implementation based on a while loop

This is 4 times faster than the old `many` in some basic tests...


```
Subjects: 5, Assertions: 0, Failures: 0, Errors: 0
suite: 134628ad035def57f08210ae05b1eb88c2d8ce07, date: 2021-03-14, stime: 22:26:52
+-----------+----------------------+-----+------+-----+------------+-----------+-----------+-----------+-----------+----------+--------+-------+
| benchmark | subject              | set | revs | its | mem_peak   | best      | mean      | mode      | worst     | stdev    | rstdev | diff  |
+-----------+----------------------+-----+------+-----+------------+-----------+-----------+-----------+-----------+----------+--------+-------+
| ManyBench | bench_takeWhile      | 0   | 10   | 10  | 1,825,752b | 97.400μs  | 109.530μs | 106.858μs | 133.200μs | 10.392μs | 9.49%  | 1.00x |
| ManyBench | bench_manySatisfy    | 0   | 10   | 10  | 1,862,264b | 208.700μs | 244.190μs | 225.526μs | 352.000μs | 41.893μs | 17.16% | 2.23x |
| ManyBench | bench_manyChar       | 0   | 10   | 10  | 1,863,008b | 232.100μs | 244.510μs | 237.852μs | 262.400μs | 9.926μs  | 4.06%  | 2.23x |
| ManyBench | bench_oldManySatisfy | 0   | 10   | 10  | 2,959,440b | 712.800μs | 765.140μs | 740.255μs | 910.400μs | 56.543μs | 7.39%  | 6.99x |
| ManyBench | bench_oldManyChar    | 0   | 10   | 10  | 2,960,192b | 733.100μs | 781.460μs | 757.570μs | 878.500μs | 48.064μs | 6.15%  | 7.13x |
+-----------+----------------------+-----+------+-----+------------+-----------+-----------+-----------+-----------+----------+--------+-------+
```