### PR TITLE
⚡️ Check for empty string using empty string instead of strlen

### DIFF
--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -63,7 +63,7 @@ final class StringStream implements Stream
      */
     public function isEOF(): bool
     {
-        return strlen($this->string) === 0;
+        return $this->string === '';
     }
 
     /**
@@ -102,7 +102,7 @@ final class StringStream implements Stream
         while ($predicate($nextToken)) {
             $chunk .= $nextToken;
             $remaining = mb_substr($remaining, 1);
-            if (mb_strlen($remaining) > 0) {
+            if ($remaining !== '') {
                 $nextToken = mb_substr($remaining, 0, 1);
             } else {
                 break;


### PR DESCRIPTION
Using strlen is a tad bit slower on short strings, but it's slower
on bigger strings. This commit just compares against empty string
instead of counting the length of the string.

Before this change:

```
Subjects: 3, Assertions: 0, Failures: 0, Errors: 0
suite: 134628b3198fb68334ea8ae03696f4b08d6c05f4, date: 2021-03-15, stime: 20:43:33
+-----------+----------------------+-----+------+-----+------------+-------------+-------------+-------------+-------------+-----------+--------+-----------+
| benchmark | subject              | set | revs | its | mem_peak   | best        | mean        | mode        | worst       | stdev     | rstdev | diff      |
+-----------+----------------------+-----+------+-----+------------+-------------+-------------+-------------+-------------+-----------+--------+-----------+
| JSONBench | bench_json_encode    | 0   | 5    | 3   | 1,708,160b | 5.200μs     | 5.200μs     | 5.200μs     | 5.200μs     | 0.000μs   | 0.00%  | 1.00x     |
| JSONBench | bench_Parsica_JSON   | 0   | 5    | 3   | 2,194,840b | 6,133.400μs | 6,244.067μs | 6,165.525μs | 6,437.400μs | 137.184μs | 2.20%  | 1,200.78x |
| JSONBench | bench_basemax_jpophp | 0   | 5    | 3   | 1,878,184b | 543.200μs   | 547.800μs   | 544.752μs   | 555.400μs   | 5.414μs   | 0.99%  | 105.35x   |
+-----------+----------------------+-----+------+-----+------------+-------------+-------------+-------------+-------------+-----------+--------+-----------+
```

After this change:

```
Subjects: 3, Assertions: 0, Failures: 0, Errors: 0
suite: 134628bc5efa46d7260730095c05fc7e10db0222, date: 2021-03-15, stime: 20:43:43
+-----------+----------------------+-----+------+-----+------------+-------------+-------------+-------------+-------------+-----------+--------+-----------+
| benchmark | subject              | set | revs | its | mem_peak   | best        | mean        | mode        | worst       | stdev     | rstdev | diff      |
+-----------+----------------------+-----+------+-----+------------+-------------+-------------+-------------+-------------+-----------+--------+-----------+
| JSONBench | bench_json_encode    | 0   | 5    | 3   | 1,708,160b | 5.200μs     | 5.333μs     | 5.388μs     | 5.400μs     | 0.094μs   | 1.77%  | 1.00x     |
| JSONBench | bench_Parsica_JSON   | 0   | 5    | 3   | 2,194,552b | 5,426.200μs | 5,959.467μs | 5,700.567μs | 6,678.000μs | 527.569μs | 8.85%  | 1,117.40x |
| JSONBench | bench_basemax_jpophp | 0   | 5    | 3   | 1,878,184b | 531.600μs   | 560.400μs   | 570.972μs   | 581.400μs   | 21.066μs  | 3.76%  | 105.08x   |
+-----------+----------------------+-----+------+-----+------------+-------------+-------------+-------------+-------------+-----------+--------+-----------+
```

looks like this is is a 10% speed improvement for the json benchmark