### PR TITLE
added benchmark-opcache composer-script which enables opcache while r…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "phpunit": "vendor/bin/phpunit",
         "psalm": "vendor/bin/psalm",
         "uptodocs": "docs/testdocs",
-        "benchmark": "phpbench run benchmarks --report=aggregate"
+        "benchmark": "phpbench run benchmarks --report=aggregate",
+        "benchmark-opcache": "phpbench run benchmarks --report=aggregate --php-config=\"{opcache.enable_cli: 1}\""
     }
 }


### PR DESCRIPTION
…unning phpbench

most production systems will run with opcache enabled, therefore we should benchmark under real world conditions