### PR TITLE
bench: use more iterations/revisions for the native json_encode baseline

### DIFF
--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -56,7 +56,7 @@ JSON;
 
     /**
      * @Revs(5)
-     * @Iterations(3)
+     * @Iterations(10)
      */
     public function bench_json_encode()
     {

--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -55,7 +55,7 @@ JSON;
     }
 
     /**
-     * @Revs(5)
+     * @Revs(10)
      * @Iterations(10)
      */
     public function bench_json_encode()


### PR DESCRIPTION
The function call is very very fast and very little differences will have a large effect on rel. comparision to parsica.
Try to make it more stable.


Motivation: in https://github.com/parsica-php/parsica/pull/45#issue-602130996 the benchmark went from 12.533μs (before-mean) to 13.333μs (after-mean) which is a diff of ~ 10% without other modifications 