### PR TITLE
Return type of first parser

### DIFF
--- a/src/combinators.php
+++ b/src/combinators.php
@@ -149,7 +149,7 @@ function sequence(Parser $first, Parser $second): Parser
  * @template T2
  * @psalm-param Parser<T1> $first
  * @psalm-param Parser<T2> $second
- * @psalm-return Parser<T2>
+ * @psalm-return Parser<T1>
  * @api
  */
 function keepFirst(Parser $first, Parser $second): Parser


### PR DESCRIPTION
If I'm not mistaken, the return type should be the return type of the first parser.